### PR TITLE
compute_origin: further reduce attribute evaluation

### DIFF
--- a/sage_explorer/explored_member.py
+++ b/sage_explorer/explored_member.py
@@ -260,11 +260,12 @@ class ExploredMember(object):
             containerclass = container
         else:
             containerclass = container.__class__
+        self.origin = None
         self.overrides = []
         for c in containerclass.__mro__:
-            if self.name in dir(c):
+            if self.name in c.__dict__:
                 self.overrides.append(c)
-                if getattr(containerclass, self.name) == getattr(c, self.name):
+                if self.origin is None: # and getattr(containerclass, self.name) == getattr(c, self.name):
                     self.origin = c
         if self.overrides:
             self.overrides = self.overrides[1:]


### PR DESCRIPTION
With the current develop, the following fails due to evaluating attributes in classes where they are not meant to be:
 
    explore(Groups())

This PR experiments with a more conservative approach: the origin is set to be the first class in the MRO that has an attribute with the given name, independently on how it evaluates. This is less exact, but anyway getting an exact value would require to evaluate the attribute on the object itself. Beside, we do not use the origin at this stage, so this can be refined later.

The PR is presumably not ready as is; e.g. some tests would be useful; here is a lower grained test case:

    from sage_explorer.explored_member import ExploredMember
    e = ExploredMember("__contains__", container=Groups().__class__)
    e.compute_origin()
